### PR TITLE
Modern chat list UI in Compose

### DIFF
--- a/app/src/main/java/mk/ukim/finki/linkup/ChatFragment.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/ChatFragment.kt
@@ -2,69 +2,44 @@ package mk.ukim.finki.linkup
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.*
-import android.widget.Button
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.firebase.ui.firestore.FirestoreRecyclerOptions
-import com.google.firebase.firestore.Query
-import com.google.firebase.Timestamp
-import com.google.firebase.firestore.Filter
-import mk.ukim.finki.linkup.adapter.RecentChatRecyclerAdapter
-import mk.ukim.finki.linkup.models.ChatRoomModel
-import mk.ukim.finki.linkup.utils.FirebaseUtil
+import androidx.fragment.app.viewModels
+import mk.ukim.finki.linkup.repository.ChatListViewModel
+import mk.ukim.finki.linkup.repository.ChatListViewModelFactory
+import mk.ukim.finki.linkup.repository.ChatRepository
+import mk.ukim.finki.linkup.ui.chatlist.ChatListScreen
+import mk.ukim.finki.linkup.ui.theme.LinkUpTheme
 
 class ChatFragment : Fragment() {
 
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var adapter: RecentChatRecyclerAdapter
+    private val viewModel: ChatListViewModel by viewModels {
+        ChatListViewModelFactory(ChatRepository())
+    }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val view = inflater.inflate(R.layout.fragment_chat, container, false)
-
-        recyclerView = view.findViewById(R.id.recyler_view)
-        setupRecyclerView()
-
-        val createGroupBtn = view.findViewById<Button>(R.id.create_group_btn)
-        createGroupBtn.setOnClickListener {
-            val intent = Intent(requireContext(), CreateGroupActivity::class.java)
-            startActivity(intent)
+    ): View {
+        viewModel.loadChats()
+        return ComposeView(requireContext()).apply {
+            setContent {
+                LinkUpTheme {
+                    ChatListScreen(
+                        viewModel = viewModel,
+                        onCreateEvent = {
+                            startActivity(Intent(context, CreateEventActivity::class.java))
+                        },
+                        onCreateGroup = {
+                            startActivity(Intent(context, CreateGroupActivity::class.java))
+                        }
+                    )
+                }
+            }
         }
-        val createEventBtn = view.findViewById<Button>(R.id.create_event_btn)
-        createEventBtn.setOnClickListener {
-            val intent = Intent(context, CreateEventActivity::class.java)
-            startActivity(intent)
-        }
-
-        return view
     }
-
-    private fun setupRecyclerView() {
-        val currentId = FirebaseUtil.currentUserId() ?: ""
-        val query = FirebaseUtil.allChatroomCollectionReference()
-            .whereArrayContains("userIds", currentId)
-            .where(
-                Filter.or(
-                    Filter.equalTo("group", true),
-                    Filter.greaterThan("lastMessageTimestamp", Timestamp(0, 0))
-                )
-            )
-            .orderBy("lastMessageTimestamp", Query.Direction.DESCENDING)
-
-        val options = FirestoreRecyclerOptions.Builder<ChatRoomModel>()
-            .setQuery(query, ChatRoomModel::class.java)
-            .setLifecycleOwner(viewLifecycleOwner)
-            .build()
-
-        adapter = RecentChatRecyclerAdapter(options, requireContext())
-        recyclerView.layoutManager = LinearLayoutManager(context)
-        recyclerView.adapter = adapter
-        recyclerView.itemAnimator = null
-    }
-
-    // FirestoreRecyclerAdapter lifecycle is managed via setLifecycleOwner
 }

--- a/app/src/main/java/mk/ukim/finki/linkup/repository/ChatListViewModel.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/repository/ChatListViewModel.kt
@@ -1,0 +1,25 @@
+package mk.ukim.finki.linkup.repository
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import mk.ukim.finki.linkup.models.ChatRoomModel
+import mk.ukim.finki.linkup.utils.FirebaseUtil
+
+class ChatListViewModel(private val repository: ChatRepository) : ViewModel() {
+    val searchQuery = mutableStateOf("")
+    private val _chatRooms = MutableStateFlow<List<ChatRoomModel>>(emptyList())
+    val chatRooms: StateFlow<List<ChatRoomModel>> = _chatRooms
+
+    fun loadChats() {
+        val userId = FirebaseUtil.currentUserId() ?: return
+        viewModelScope.launch {
+            repository.getUserChatRoomsFlow(userId).collect { rooms ->
+                _chatRooms.value = rooms
+            }
+        }
+    }
+}

--- a/app/src/main/java/mk/ukim/finki/linkup/repository/ChatListViewModelFactory.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/repository/ChatListViewModelFactory.kt
@@ -1,0 +1,14 @@
+package mk.ukim.finki.linkup.repository
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class ChatListViewModelFactory(private val repository: ChatRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ChatListViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ChatListViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/ChatCard.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/ChatCard.kt
@@ -1,0 +1,50 @@
+package mk.ukim.finki.linkup.ui.chatlist
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import mk.ukim.finki.linkup.models.ChatRoomModel
+import mk.ukim.finki.linkup.utils.FirebaseUtil
+
+@Composable
+fun ChatCard(chat: ChatRoomModel, modifier: Modifier = Modifier) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Icon(
+                imageVector = Icons.Default.Person,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(chat.groupName.ifEmpty { "Chat" }, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = chat.lastMessage,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Text(
+                text = FirebaseUtil.timestampToString(chat.lastMessageTimestamp),
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/ChatListScreen.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/ChatListScreen.kt
@@ -1,0 +1,42 @@
+package mk.ukim.finki.linkup.ui.chatlist
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.runtime.remember
+import androidx.compose.material3.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import mk.ukim.finki.linkup.repository.ChatListViewModel
+
+@Composable
+fun ChatListScreen(
+    viewModel: ChatListViewModel,
+    onCreateEvent: () -> Unit,
+    onCreateGroup: () -> Unit
+) {
+    val chats by viewModel.chatRooms.collectAsState()
+    val query = remember { viewModel.searchQuery }
+
+    Scaffold(
+        topBar = {
+            SearchTopAppBar(query.value) { viewModel.searchQuery.value = it }
+        },
+        floatingActionButton = {
+            ExpandableFab(onCreateEvent, onCreateGroup)
+        }
+    ) { inner ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+        ) {
+            items(chats) { chat ->
+                ChatCard(chat)
+            }
+        }
+    }
+}

--- a/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/ExpandableFab.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/ExpandableFab.kt
@@ -1,0 +1,23 @@
+package mk.ukim.finki.linkup.ui.chatlist
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+
+@Composable
+fun ExpandableFab(onCreateEvent: () -> Unit, onCreateGroup: () -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    FloatingActionButton(onClick = { expanded = !expanded }) {
+        Icon(if (expanded) Icons.Default.Close else Icons.Default.Add, contentDescription = null)
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        DropdownMenuItem(text = { Text("Create Event") }, onClick = { expanded = false; onCreateEvent() })
+        DropdownMenuItem(text = { Text("Create Group") }, onClick = { expanded = false; onCreateGroup() })
+    }
+}

--- a/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/SearchTopAppBar.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/ui/chatlist/SearchTopAppBar.kt
@@ -1,0 +1,25 @@
+package mk.ukim.finki.linkup.ui.chatlist
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SearchTopAppBar(query: String, onQueryChange: (String) -> Unit) {
+    CenterAlignedTopAppBar(
+        title = {
+            TextField(
+                value = query,
+                onValueChange = onQueryChange,
+                placeholder = { Text("Search chats") },
+                singleLine = true,
+                colors = TextFieldDefaults.colors(),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    )
+}

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -1,44 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/chat_compose"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:context=".ChatFragment">
-
-    <!-- Create Group Button -->
-    <Button
-        android:id="@+id/create_group_btn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Create Group"
-        android:layout_margin="12dp"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true"
-        android:backgroundTint="@color/my_primary"
-        android:textColor="@android:color/white"
-        android:elevation="2dp"/>
-
-    <!-- Create Event Button - placed to the left of Create Group -->
-    <Button
-        android:id="@+id/create_event_btn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Create Event"
-        android:layout_margin="12dp"
-        android:layout_alignParentTop="true"
-        android:layout_toStartOf="@id/create_group_btn"
-        android:backgroundTint="@color/my_primary"
-        android:textColor="@android:color/white"
-        android:elevation="2dp"/>
-
-    <!-- RecyclerView for chat list -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyler_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/create_group_btn"
-        android:paddingTop="8dp"
-        android:paddingBottom="12dp"/>
-</RelativeLayout>
-
+    android:layout_height="match_parent" />

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,11 +1,7 @@
 <resources>
-    <style name="Theme.LinkUp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.LinkUp" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/my_primary</item>
-        <item name="colorPrimaryVariant">@color/my_primary</item>
-        <item name="colorOnPrimary">@color/black</item>
         <item name="colorSecondary">@color/my_secondary</item>
-        <item name="colorSecondaryVariant">@color/my_secondary</item>
-        <item name="colorOnSecondary">@color/black</item>
         <item name="android:windowBackground">@color/off_white</item>
         <item name="android:windowAnimationStyle">@style/AppAnim</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,17 +1,10 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.LinkUp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.LinkUp" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/my_primary</item>
-        <item name="colorPrimaryVariant">@color/my_primary</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/my_secondary</item>
-        <item name="colorSecondaryVariant">@color/my_secondary</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
         <item name="android:windowBackground">@color/off_white</item>
         <item name="android:windowAnimationStyle">@style/AppAnim</item>
     </style>


### PR DESCRIPTION
## Summary
- rebuild `ChatFragment` with Jetpack Compose
- implement `ChatListScreen`, `ChatCard`, `ExpandableFab`, `SearchTopAppBar`
- create `ChatListViewModel` and repository flow for chatrooms
- switch app themes to Material3

## Testing
- `./gradlew assembleDebug` *(fails: Unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688547c964c88333ad6528bdcd7d7fe1