### PR TITLE
Use activity context for chat message inflation

### DIFF
--- a/app/src/main/java/mk/ukim/finki/linkup/ChatActivity.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/ChatActivity.kt
@@ -165,7 +165,10 @@ class ChatActivity : AppCompatActivity() {
             .setLifecycleOwner(this)
             .build()
 
-        adapter = ChatRecyclerAdapter(options, applicationContext, chatroomModel)
+        // Use the activity context so Material components can access the correct theme
+        // Application context lacks theme information which causes MaterialCardView inflation
+        // to fail with "The style on this component requires your app theme to be Theme.MaterialComponents".
+        adapter = ChatRecyclerAdapter(options, this, chatroomModel)
 
         val manager = LinearLayoutManager(this).apply {
             reverseLayout = true // gi setira porakite vo descending order, poslednoto pishano e najdolu

--- a/app/src/main/java/mk/ukim/finki/linkup/MainActivity.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/MainActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.widget.ImageButton
+import android.widget.RelativeLayout
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -24,6 +25,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var bottomNavigationView: BottomNavigationView
     private lateinit var searchButton: ImageButton
+    private lateinit var mainToolbar: RelativeLayout
     private lateinit var chatFragment: ChatFragment
     private lateinit var profileFragment: ProfileFragment
     private lateinit var fusedLocationClient: FusedLocationProviderClient
@@ -46,6 +48,11 @@ class MainActivity : AppCompatActivity() {
 
         bottomNavigationView = findViewById(R.id.bottom_navigation)
         searchButton = findViewById(R.id.main_searchButton)
+        mainToolbar = findViewById(R.id.main_toolbar)
+
+        val params = mainToolbar.layoutParams
+        params.height = (resources.displayMetrics.heightPixels * 0.1).toInt()
+        mainToolbar.layoutParams = params
 
         searchButton.setOnClickListener {
             startActivity(Intent(this, SearchUserActivity::class.java))

--- a/app/src/main/java/mk/ukim/finki/linkup/adapter/ChatRecyclerAdapter.kt
+++ b/app/src/main/java/mk/ukim/finki/linkup/adapter/ChatRecyclerAdapter.kt
@@ -4,15 +4,14 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.firebase.ui.firestore.FirestoreRecyclerAdapter
 import com.firebase.ui.firestore.FirestoreRecyclerOptions
+import com.google.android.material.card.MaterialCardView
 import mk.ukim.finki.linkup.R
 import mk.ukim.finki.linkup.models.ChatMessageModel
 import mk.ukim.finki.linkup.models.ChatRoomModel
-import mk.ukim.finki.linkup.models.UserModel
 import mk.ukim.finki.linkup.utils.FirebaseUtil
 
 class ChatRecyclerAdapter(
@@ -72,8 +71,8 @@ class ChatRecyclerAdapter(
     class ChatMessageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val leftChatText: TextView = itemView.findViewById(R.id.left_chat_textview)
         val rightChatText: TextView = itemView.findViewById(R.id.right_chat_textview)
-        val leftChatLayout: LinearLayout = itemView.findViewById(R.id.left_chat_layout)
-        val rightChatLayout: LinearLayout = itemView.findViewById(R.id.right_chat_layout)
+        val leftChatLayout: MaterialCardView = itemView.findViewById(R.id.left_chat_layout)
+        val rightChatLayout: MaterialCardView = itemView.findViewById(R.id.right_chat_layout)
         val senderName: TextView = itemView.findViewById(R.id.sender_name_textview)
         val senderNameRight: TextView = itemView.findViewById(R.id.sender_name_right)
 

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -41,9 +41,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
-                android:layout_centerVertical="true"
-                android:layout_toRightOf="@id/profile_pic_layout"
-                android:layout_toLeftOf="@id/members_btn"
+                android:layout_marginEnd="64dp"
+                android:layout_gravity="center_vertical"
                 android:text="Username"
                 android:textColor="@color/white"
                 android:textSize="22sp"
@@ -54,10 +53,10 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/person_icon"
-                android:layout_alignParentEnd="true"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 app:tint="@color/white"
-                android:layout_centerVertical="true" />
+                android:layout_gravity="end|center_vertical"
+                android:layout_marginEnd="10dp" />
         </com.google.android.material.appbar.MaterialToolbar>
 
         <Button

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/my_primary"
-        android:padding="100dp">
+        android:padding="10dp">
 
         <TextView
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- Ensure ChatRecyclerAdapter inflates views with activity context so Material components receive the correct theme
- Replace LinearLayout references with MaterialCardView to match layout definitions and avoid class cast errors

## Testing
- `./gradlew test` *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c6732c6f088333b045cc4e05ec9d2f